### PR TITLE
Remove Retrolambda config & Fixes the build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,15 +30,6 @@ android {
     }
 }
 
-retrolambda {
-    jdk System.getenv("JAVA8_HOME")
-    oldJdk System.getenv("JAVA7_HOME")
-    javaVersion JavaVersion.VERSION_1_7
-    jvmArgs '-noverify'
-    defaultMethods false
-    incremental true
-}
-
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {


### PR DESCRIPTION
The build was failing for me with the following error:
```
An exception has occurred in the compiler (1.8.0_25). Please file a bug at the Java Developer Connection (http://java.sun.com/webapps/bugreport)  after checking the Bug Parade for duplicates. Include your program and the following diagnostic in your report.  Thank you.
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for java.lang.invoke.MethodType not found
```

Not sure why you need a Retrolambda config. AFAIK the default settings for Retrolamda work perfectly. 