### PR TITLE
Replace Observable.create with Observable.fromEmitter

### DIFF
--- a/app/src/main/java/agency/tango/databindingrxjava/MainActivity.java
+++ b/app/src/main/java/agency/tango/databindingrxjava/MainActivity.java
@@ -1,5 +1,6 @@
 package agency.tango.databindingrxjava;
 
+import android.app.Activity;
 import android.databinding.DataBindingUtil;
 import android.databinding.ObservableBoolean;
 import android.databinding.ObservableField;


### PR DESCRIPTION
`Observable.fromEmitter` is the recommended way of bridging the callback world with callback apis. 